### PR TITLE
hotfix: get_per_str works when no mat_id supplied

### DIFF
--- a/material.py
+++ b/material.py
@@ -323,8 +323,11 @@ class mat_lib():
             return data
 
     def get_per_str(self, *args, **kwargs):
-
-        return np.divide(self.get(*args, **kwargs), 4.0*np.pi)
+        try:
+            return np.divide(self.get(*args, **kwargs), 4.0*np.pi)
+        except TypeError:
+            return {k: np.divide(v, 4.0*np.pi) for k, v
+                    in self.get(*args, **kwargs).iteritems()}
 
     def props(self, mat_id=None):
         data = {}


### PR DESCRIPTION
Fixes #15. Recommend merging via rebase.