### PR TITLE
Removes cell_corrections, adds solution plotting

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,6 @@
 [run]
 omit=./tests/*
 source=.
+
+[html]
+directory = htmlcov

--- a/material.py
+++ b/material.py
@@ -376,7 +376,7 @@ class mat_map():
 
         self.array = self.__build_array__()
 
-    def plot(self):
+    def plot(self): # pragma: no cover
         n = int(np.sqrt(len(self.array)))
         mat_set = list(set(self.array))
         layout = [self.array[x:x+n] 

--- a/material.py
+++ b/material.py
@@ -63,17 +63,6 @@ class _mat():
 
     # PUBLIC FUNCTIONS
 
-    def cell_correction_ua(self, cell_correction):
-        i = int(self.gconst['g_thermal'])
-        v_x = np.dot(cell_correction[0][i:], self.derived['ksi_ua'])
-        v_y = np.dot(cell_correction[1][i:], self.derived['ksi_ua'])
-
-        return np.array([v_x, v_y])
-
-    def bd_correction_ua(self, bd_correction):
-        return np.dot(bd_correction, self.derived['ksi_ua'])
-
-
     def get_props(self):
         # Returns an array of all the properties that the material has
         return [d.keys() for d in self.all_dict]
@@ -300,36 +289,8 @@ class mat_lib():
             raise RuntimeError("Cannot add file " + filename +
                   ", mat_id already exists in material library")
 
-    def cell_correction_ua(self, correction, mat_id=None):
-        data = self.__correction__(correction, c_type='cell')
-
-        if mat_id:
-            return data[mat_id]
-        else:
-            return data
-
-    def bd_correction_ua(self, correction, mat_id=None):
-        data = self.__correction__(correction, c_type='bd')
-
-        if mat_id:
-            return data[mat_id]
-        else:
-            return data
-
     def n_grps(self):
         return self._n_grps
-        
-    def __correction__(self, correction, c_type):
-
-        data = {}
-        for mat in self.mats:
-            if c_type == 'cell':
-                data.update({mat.get('id') :
-                             mat.cell_correction_ua(correction)})
-            else:
-                data.update({mat.get('id') :
-                             mat.bd_correction_ua(correction)})
-        return data
 
     def ids(self):
         """ Returns the id's of stored materials """
@@ -448,23 +409,6 @@ class mat_map():
             k = loc
 
         return self.mat_lib.get(prop=prop, mat_id=self.array[k])
-
-    def cell_correction_ua(self, correction, loc):
-        if isinstance(loc, tuple):
-            k = int(loc[0]/self.dx) + int(loc[1]/self.dy)*self.n
-        else:
-            k = loc
-        return self.mat_lib.cell_correction_ua(correction,
-                                               mat_id=self.array[k])
-
-    def bd_correction_ua(self, correction, loc):
-        if isinstance(loc, tuple):
-            k = int(loc[0]/self.dx) + int(loc[1]/self.dy)*self.n
-        else:
-            k = loc
-        return self.mat_lib.bd_correction_ua(correction,
-                                             mat_id=self.array[k])
-
 
     def __build_array__(self):
         # Builds the array

--- a/mesh.py
+++ b/mesh.py
@@ -1,3 +1,7 @@
+import matplotlib.pyplot as plt
+from mpl_toolkits.mplot3d import Axes3D
+from matplotlib import cm
+
 import numpy as np
 
 class Mesh(object):
@@ -28,7 +32,50 @@ class Mesh(object):
     self._y_node = mesh_cells + 1
     self._n_node = self._x_node * self._y_node
     self._cell_length = self._mesh_params['cell_length']
+
+  def soln_plot(self, solution, plot = True): # pragma: no cover
+    # Plot a given solution
+    return self.__plot__(solution, plot)
     
+  def test_plot(self, plot = False):
+    # Plot a test solution of length n_cells
+    solution = np.zeros(self._n_node)
+    
+    for cell in self._cells:
+      for idx in cell.global_idx():
+        solution[idx] += 0.5
+        
+    return self.__plot__(solution, plot)
+
+  def __plot__(self, solution, plot):
+    xs = []
+    ys = []
+    zs = []
+    for i,s in enumerate(solution):
+      x, y = self.__idx_to_xy__(i)
+      xs.append(x)
+      ys.append(y)
+      zs.append(s)
+    if plot: # pragma: no cover
+      fig = plt.figure()
+      ax = fig.add_subplot(111, projection='3d')
+      X = np.reshape(xs, (self._x_node, self._x_node))
+      Y = np.reshape(ys, (self._x_node, self._x_node))
+      Z = np.reshape(zs, (self._x_node, self._x_node))
+      rstride = int(self._x_node/50) + 1
+      cstride = int(self._x_node/50) + 1
+      surf = ax.plot_surface(X,Y,Z, cmap=cm.coolwarm, rstride=rstride,
+                             cstride=cstride, linewidth=0, antialiased=False)
+      fig.colorbar(surf)
+      plt.show()
+      return fig
+    else:
+      return xs, ys, zs
+
+  def __idx_to_xy__(self, idx):
+    y = self._cell_length*int(idx/self._x_node)
+    x = self._cell_length*int(idx % self._y_node)
+    return (x,y)
 
   def cell_length(self):
     return self._cell_length

--- a/mesh.py
+++ b/mesh.py
@@ -5,195 +5,195 @@ from matplotlib import cm
 import numpy as np
 
 class Mesh(object):
-  def __init__(self, mesh_cells, domain_upper, mat_map):
-    assert type(mesh_cells) == int, "mesh_cells must be an int"
-    self._mesh_params = {'x_cell': mesh_cells,
-                         'cell_length': float(domain_upper)/float(mesh_cells)}
+    def __init__(self, mesh_cells, domain_upper, mat_map):
+        assert type(mesh_cells) == int, "mesh_cells must be an int"
+        self._mesh_params = {'x_cell': mesh_cells,
+                             'cell_length': float(domain_upper)/float(mesh_cells)}
 
-    self._mat_map = mat_map
+        self._mat_map = mat_map
 
-    i = np.repeat(np.arange(mesh_cells), mesh_cells)
-    j = np.tile(np.arange(mesh_cells), mesh_cells)
-    idxs = zip(i,j)
-
-    self._cells = []
-
-    for idx in idxs:
-      self._cells.append(Cell(idx, self._mesh_params, mat_map))
-
-    # Save parameters
-    self._n_cell = mesh_cells**2
-    assert self._n_cell == len(self._cells),\
-                          "Cell array incorrect length"
-
-    self._x_cell = mesh_cells
-    self._y_cell = mesh_cells
-    self._x_node = mesh_cells + 1
-    self._y_node = mesh_cells + 1
-    self._n_node = self._x_node * self._y_node
-    self._cell_length = self._mesh_params['cell_length']
-
-  def soln_plot(self, solution, plot = True): # pragma: no cover
-    # Plot a given solution
-    return self.__plot__(solution, plot)
+        i = np.repeat(np.arange(mesh_cells), mesh_cells)
+        j = np.tile(np.arange(mesh_cells), mesh_cells)
+        idxs = zip(i,j)
     
-  def test_plot(self, plot = False):
-    # Plot a test solution of length n_cells
-    solution = np.zeros(self._n_node)
-    
-    for cell in self._cells:
-      for idx in cell.global_idx():
-        solution[idx] += 0.5
+        self._cells = []
+
+        for idx in idxs:
+            self._cells.append(Cell(idx, self._mesh_params, mat_map))
+
+        # Save parameters
+        self._n_cell = mesh_cells**2
+        assert self._n_cell == len(self._cells),\
+            "Cell array incorrect length"
+
+        self._x_cell = mesh_cells
+        self._y_cell = mesh_cells
+        self._x_node = mesh_cells + 1
+        self._y_node = mesh_cells + 1
+        self._n_node = self._x_node * self._y_node
+        self._cell_length = self._mesh_params['cell_length']
+
+    def soln_plot(self, solution, plot = True): # pragma: no cover
+        # Plot a given solution
+        return self.__plot__(solution, plot)
         
-    return self.__plot__(solution, plot)
+    def test_plot(self, plot = False):
+        # Plot a test solution of length n_cells
+        solution = np.zeros(self._n_node)
+            
+        for cell in self._cells:
+            for idx in cell.global_idx():
+                solution[idx] += 0.5
+                    
+        return self.__plot__(solution, plot)
+                
+    def __plot__(self, solution, plot):
+        xs = []
+        ys = []
+        zs = []
+        for i,s in enumerate(solution):
+            x, y = self.__idx_to_xy__(i)
+            xs.append(x)
+            ys.append(y)
+            zs.append(s)
+        if plot: # pragma: no cover
+            fig = plt.figure()
+            ax = fig.add_subplot(111, projection='3d')
+            X = np.reshape(xs, (self._x_node, self._x_node))
+            Y = np.reshape(ys, (self._x_node, self._x_node))
+            Z = np.reshape(zs, (self._x_node, self._x_node))
+            rstride = int(self._x_node/50) + 1
+            cstride = int(self._x_node/50) + 1
+            surf = ax.plot_surface(X,Y,Z, cmap=cm.coolwarm, rstride=rstride,
+                                   cstride=cstride, linewidth=0, antialiased=False)
+            fig.colorbar(surf)
+            plt.show()
+            return fig
+        else:
+            return xs, ys, zs
 
-  def __plot__(self, solution, plot):
-    xs = []
-    ys = []
-    zs = []
-    for i,s in enumerate(solution):
-      x, y = self.__idx_to_xy__(i)
-      xs.append(x)
-      ys.append(y)
-      zs.append(s)
-    if plot: # pragma: no cover
-      fig = plt.figure()
-      ax = fig.add_subplot(111, projection='3d')
-      X = np.reshape(xs, (self._x_node, self._x_node))
-      Y = np.reshape(ys, (self._x_node, self._x_node))
-      Z = np.reshape(zs, (self._x_node, self._x_node))
-      rstride = int(self._x_node/50) + 1
-      cstride = int(self._x_node/50) + 1
-      surf = ax.plot_surface(X,Y,Z, cmap=cm.coolwarm, rstride=rstride,
-                             cstride=cstride, linewidth=0, antialiased=False)
-      fig.colorbar(surf)
-      plt.show()
-      return fig
-    else:
-      return xs, ys, zs
-
-  def __idx_to_xy__(self, idx):
-    y = self._cell_length*int(idx/self._x_node)
-    x = self._cell_length*int(idx % self._y_node)
-    return (x,y)
-
-  def cell_length(self):
-    return self._cell_length
+    def __idx_to_xy__(self, idx):
+        y = self._cell_length*int(idx/self._x_node)
+        x = self._cell_length*int(idx % self._y_node)
+        return (x,y)
     
-  def cells(self):
-    return self._cells
-
-  def n_cell(self):
-    return self._n_cell
-
-  def n_node(self):
-    return self._n_node
-
-  def x_cell(self):
-    return self._x_cell
-
-  def x_node(self):
-    return self._x_node
-
-  def y_cell(self):
-    return self._y_cell
-
-  def y_node(self):
-    return self._y_node
+    def cell_length(self):
+        return self._cell_length
+    
+    def cells(self):
+        return self._cells
+    
+    def n_cell(self):
+        return self._n_cell
+    
+    def n_node(self):
+        return self._n_node
+    
+    def x_cell(self):
+        return self._x_cell
+    
+    def x_node(self):
+        return self._x_node
+    
+    def y_cell(self):
+        return self._y_cell
+    
+    def y_node(self):
+        return self._y_node
 
 class Cell(object):
-  """ A single cell in the mesh, holds location and material data """
+    """ A single cell in the mesh, holds location and material data """
 
-  def __init__(self, index, mesh_params, mat_map=None):
-    """ Cell constructor, give index in a tuple (i,j) """
+    def __init__(self, index, mesh_params, mat_map=None):
+        """ Cell constructor, give index in a tuple (i,j) """
     
-    # Constructor validations
-    assert isinstance(index, tuple), "Index must be a tuple"
-    assert len(index) == 2, "Index must be a length 2 tuple"
+        # Constructor validations
+        assert isinstance(index, tuple), "Index must be a tuple"
+        assert len(index) == 2, "Index must be a length 2 tuple"
     
-    try:
-      assert mesh_params['cell_length'] > 0, "cell_length must be greater than 0"
-    except KeyError:
-      raise KeyError("Missing 'cell_length' parameter in mesh_params")
+        try:
+            assert mesh_params['cell_length'] > 0, "cell_length must be greater than 0"
+        except KeyError:
+            raise KeyError("Missing 'cell_length' parameter in mesh_params")
 
-    self._index  = index
+        self._index  = index
 
-    try:
-      self._length = float(mesh_params['cell_length'])
-    except ValueError:
-      raise TypeError("cell_length parameter must be a number")
+        try:
+            self._length = float(mesh_params['cell_length'])
+        except ValueError:
+            raise TypeError("cell_length parameter must be a number")
 
-    # Calculate global_idx
-    x_node = mesh_params['x_cell'] + 1
-    i,j = index[0], index[1]
-    self._global_idx = [x_node*i + j,
-                        x_node*i + j + 1,
-                        x_node*(i + 1) + j,
-                        x_node*(i + 1) + j + 1]
+        # Calculate global_idx
+        x_node = mesh_params['x_cell'] + 1
+        i,j = index[0], index[1]
+        self._global_idx = [x_node*i + j,
+                            x_node*i + j + 1,
+                            x_node*(i + 1) + j,
+                            x_node*(i + 1) + j + 1]
     
-    # Determine if on a boundary
-    self._bounds = {}
-    x_cell = mesh_params['x_cell']
-    try:
-      y_cell = mesh_params['y_cell']
-    except KeyError:
-      y_cell = x_cell
-
-    # Verify cell is in the mesh
-    assert i < x_cell, "Cell i exceeds num of x nodes"
-    assert j < y_cell, "Cell j exceeds num of y nodes"
+        # Determine if on a boundary
+        self._bounds = {}
+        x_cell = mesh_params['x_cell']
+        try:
+            y_cell = mesh_params['y_cell']
+        except KeyError:
+            y_cell = x_cell
+            
+        # Verify cell is in the mesh
+        assert i < x_cell, "Cell i exceeds num of x nodes"
+        assert j < y_cell, "Cell j exceeds num of y nodes"
       
-    if index[0] == 0:
-      self._bounds.update({'x_min': None})
-    if index[0] == y_cell - 1:
-      self._bounds.update({'x_max': None})
-    if index[1] == 0:
-      self._bounds.update({'y_min': None})
-    if index[1] == x_cell - 1:
-      self._bounds.update({'y_max': None})
+        if index[0] == 0:
+            self._bounds.update({'x_min': None})
+        if index[0] == y_cell - 1:
+            self._bounds.update({'x_max': None})
+        if index[1] == 0:
+            self._bounds.update({'y_min': None})
+        if index[1] == x_cell - 1:
+            self._bounds.update({'y_max': None})
 
-    # Get material properties
-    if mat_map:
-      assert (mat_map.dx * mat_map.n) == (x_cell * self._length),\
-        "Material map and cells must have the same total x length"
-      assert (mat_map.dy * mat_map.n) == (y_cell * self._length),\
-        "Material map and cells must have the same total y length"
+        # Get material properties
+        if mat_map:
+            assert (mat_map.dx * mat_map.n) == (x_cell * self._length),\
+                "Material map and cells must have the same total x length"
+            assert (mat_map.dy * mat_map.n) == (y_cell * self._length),\
+                "Material map and cells must have the same total y length"
       
-      self._mat_map = mat_map
+        self._mat_map = mat_map
 
 
-  # UTILITY FUNCTIONS ================================================
+    # UTILITY FUNCTIONS ================================================
 
-  # MATERIAL PROPERTIES  ==============================================
-  def get(self, prop):
-    try:
-      x = self._length*(self._index[0] + 0.5)
-      y = self._length*(self._index[1] + 0.5)
+    # MATERIAL PROPERTIES  ==============================================
+    def get(self, prop):
+        try:
+            x = self._length*(self._index[0] + 0.5)
+            y = self._length*(self._index[1] + 0.5)
     
-      return self._mat_map.get(prop, loc=(x,y))
-    except AttributeError:
-      raise AttributeError("This cell has no material map assigned")
+            return self._mat_map.get(prop, loc=(x,y))
+        except AttributeError:
+            raise AttributeError("This cell has no material map assigned")
 
   
-  # ATTRIBUTES  =======================================================
+    # ATTRIBUTES  =======================================================
       
-  def bounds(self, bound=None, value=None):
-    if bound and bound in self._bounds:
-      if value:
-        self._bounds[bound] = value
-      else:
-        return self._bounds[bound]
-    elif bound and not bound in self._bounds:
-      raise KeyError("Cell does not have bound " + str(bound))
-    else:
-      return self._bounds    
+    def bounds(self, bound=None, value=None):
+        if bound and bound in self._bounds:
+            if value:
+                self._bounds[bound] = value
+            else:
+                return self._bounds[bound]
+        elif bound and not bound in self._bounds:
+            raise KeyError("Cell does not have bound " + str(bound))
+        else:
+            return self._bounds    
   
-  def global_idx(self):
-    """ Returns global index, a list of the node indices """
-    return self._global_idx
+    def global_idx(self):
+        """ Returns global index, a list of the node indices """
+        return self._global_idx
 
-  def index(self):
-    return self._index
+    def index(self):
+        return self._index
   
-  def length(self):
-    return self._length
+    def length(self):
+        return self._length

--- a/mesh.py
+++ b/mesh.py
@@ -73,7 +73,6 @@ class Cell(object):
 
     try:
       self._length = float(mesh_params['cell_length'])
-      self._area   = np.power(self._length, 2)
     except ValueError:
       raise TypeError("cell_length parameter must be a number")
 
@@ -130,10 +129,7 @@ class Cell(object):
 
   
   # ATTRIBUTES  =======================================================
-    
-  def area(self):
-    return self._area
-  
+      
   def bounds(self, bound=None, value=None):
     if bound and bound in self._bounds:
       if value:

--- a/tests/cell_tests.py
+++ b/tests/cell_tests.py
@@ -14,7 +14,6 @@ class TestCells:
 
     def test_area(self):
         """ Cell should be the correct area """
-        eq_(self.cell.area(), 2.5**2, "area value")
         eq_(self.cell.length(), 2.5, "length value")
 
     def test_global_index(self):

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -51,8 +51,36 @@ class TestIntegration_Mesh_Materials:
         eq_(mesh.x_node(), 5, "x_node value")
         eq_(mesh.y_node(), 5, "y_node value")
         eq_(mesh.cell_length(), 2.5, "cell length value")
-        
 
+    def test_plotting(self):
+        mesh_cells = 4
+        domain_upper = 10
+        mesh = Mesh(mesh_cells, domain_upper, self.testmap)
+        mesh_params = {'x_cell': 4,
+                       'cell_length': 2.5}
+        x_ans   = [0, 2.5, 5.0, 7.5, 10.0,
+               0, 2.5, 5.0, 7.5, 10.0,
+               0, 2.5, 5.0, 7.5, 10.0,
+               0, 2.5, 5.0, 7.5, 10.0,
+               0, 2.5, 5.0, 7.5, 10.0]
+
+        y_ans   = [0, 0, 0, 0, 0,
+               2.5, 2.5, 2.5, 2.5, 2.5,
+               5.0, 5.0, 5.0, 5.0, 5.0,
+               7.5, 7.5, 7.5, 7.5, 7.5,
+               10.0, 10.0, 10.0, 10.0, 10.0]
+
+        ans = [0.5, 1.0, 1.0, 1.0, 0.5,
+               1.0, 2.0, 2.0, 2.0, 1.0,
+               1.0, 2.0, 2.0, 2.0, 1.0,
+               1.0, 2.0, 2.0, 2.0, 1.0,
+               0.5, 1.0, 1.0, 1.0, 0.5]
+        
+        x, y, z = mesh.test_plot(plot=False)
+        ok_(np.array_equal(x, x_ans), "x values")
+        ok_(np.array_equal(y, y_ans), "y values")
+        ok_(np.array_equal(ans, z), "z values")
+        
     @raises(AssertionError)
     def test_mesh_cells_is_int(self):
         mesh_cells = 4.5

--- a/tests/mat_lib_tests.py
+++ b/tests/mat_lib_tests.py
@@ -49,6 +49,11 @@ class TestFunctionality:
                                              'test_mat'),
                         np.array([15.91549431, 23.87324146])))
 
+    def test_get_str_dict(self):
+        """ get_per_str should return correct values (no mat_id)"""
+        ok_(np.allclose(self.lib.get_per_str('sig_t')['test_mat'],
+                        np.array([15.91549431, 23.87324146])))
+
     def test_get_id(self):
         """ providing an id and a prop returns the array for that mat """
         ok_(np.array_equal(self.lib.get('sig_t', mat_id='test_mat'),


### PR DESCRIPTION
This removes the `bd_correction_ua` and `cell_correction_ua` functions from all material classes. Adds `Mesh.test_plot()` for testing the global mapping, which returns (x,y,z) for each node, where z is a stamped 0.5 value at each cell corner. Adds a plotting function to the mesh, `Mesh.soln_plot(solution)` that will plot the solution. For example:
```
mesh = mesh.Mesh(100, 10, mat_map)
x, y, z = mesh.test_plot()
for i, v in enumerate(z):
    z[i] = -(x[i] - 5)**2 - (y[i] - 5)**2
mesh.plot_soln(z)
```
Produces this plot:
![solution](https://user-images.githubusercontent.com/11690134/31518983-bd692bc4-af55-11e7-9205-0119031b76b3.png)
